### PR TITLE
Lfocv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,6 @@ Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes
 SystemRequirements: GNU make
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: 
     testthat (>= 2.1.0)

--- a/man/fitted.bmgarch.Rd
+++ b/man/fitted.bmgarch.Rd
@@ -4,7 +4,14 @@
 \alias{fitted.bmgarch}
 \title{Fitted (backcasting) method for bmgarch objects.}
 \usage{
-\method{fitted}{bmgarch}(object, CrI = c(0.025, 0.975), digits = 2, weights = NULL, ...)
+\method{fitted}{bmgarch}(
+  object,
+  CrI = c(0.025, 0.975),
+  digits = 2,
+  weights = NULL,
+  inc_samples = FALSE,
+  ...
+)
 }
 \arguments{
 \item{object}{bmgarch object.}
@@ -12,6 +19,10 @@
 \item{CrI}{Numeric vector (Default: \code{c(.025, .975)}). Lower and upper bound of predictive credible interval.}
 
 \item{digits}{Integer (Default: 2, optional). Number of digits to round to when printing.}
+
+\item{weights}{Takes weights from model_weight function. Defaults to 1 -- this parameter is not typically set by user.}
+
+\item{inc_samples}{Logical (Default: FALSE). Whether to return the MCMC samples for the fitted values.}
 
 \item{...}{Not used.}
 }
@@ -21,6 +32,7 @@ fitted.bmgarch object. List containing \code{meta}data and the \code{backcast}. 
   \item{mean}{\code{[N, 7, TS]} array of mean backcasts, where N is the timeseries length, and TS is the number of time series. E.g., \code{bc$backcast$mean[3,,"tsA"]} is the mean backcast for the third observation in time series "tsA".}
   \item{var}{\code{[N, 7, TS]} array of variance backcasts, where N is the timeseries length, and TS is the number of time series. E.g., \code{bc$backcast$var[3,,"tsA"]} is the variance backcast for the third observation in time series "tsA".}
   \item{cor}{\code{[N, 7, TS(TS - 1)/2]} array of correlation backcasts, where N is the timeseries length, and \code{TS(TS - 1)/2} is the number of correlations. E.g., \code{bc$backcast$cor[3,, "tsB_tsA"]} is the backcast for the correlation between "tsB" and "tsA" on the third observation. Lower triangular correlations are saved.}
+  \item{samples}{List}. If inc_samples is \code{TRUE}, then a list of arrays of MCMC samples for means, vars, and cors. Each array is [Iteration, Period, ..., ...].
 }
 }
 \description{

--- a/man/forecast.bmgarch.Rd
+++ b/man/forecast.bmgarch.Rd
@@ -14,7 +14,8 @@
   digits = 2,
   weights = NULL,
   L = NA,
-  method = "stacking"
+  method = "stacking",
+  inc_samples = FALSE
 )
 }
 \arguments{
@@ -32,7 +33,7 @@
 
 \item{digits}{Integer (Default: 2, optional). Number of digits to round to when printing.}
 
-\item{weight}{Takes weights from model_weight function. Defaults to 1 -- this parameter is not typically set by user.}
+\item{weights}{Takes weights from model_weight function. Defaults to 1 -- this parameter is not typically set by user.}
 }
 \value{
 forecast.bmgarch object. List containing \code{forecast}, \code{backcast}, and \code{meta}data.
@@ -43,6 +44,7 @@ See \code{\link{fitted.bmgarch}} for information on \code{backcast}.
   \item{var}{\code{[N, 7, TS]} array of variance forecasts, where N is the timeseries length, and TS is the number of time series. E.g., \code{fc$forecast$var[3,,"tsA"]} is the 3-ahead variance forecast for time series "tsA".}
   \item{cor}{\code{[N, 7, TS(TS - 1)/2]} array of correlation forecasts, where N is the timeseries length, and \code{TS(TS - 1)/2} is the number of correlations. E.g., \code{fc$forecast$cor[3,, "tsB_tsA"]} is the 3-ahead forecast for the correlation between "tsB" and "tsA". Lower triangular correlations are saved.}
   \item{meta}{Meta-data specific to the forecast. I.e., TS_length (number ahead) and xC.}
+  \item{samples}{List}. If inc_samples is \code{TRUE}, then a list of arrays of MCMC samples for means, vars, and cors. Each array is [Iteration, Period, ..., ...].
 }
 }
 \description{

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -193,7 +193,7 @@ fit1 <- bmgarch(data = stocks[1:100, c("toyota",  "nissan" )],
 
 summary(fit1)
 
-fc <- forecast(fit, ahead = 1, xC = cbind(stocks[101, c("honda")], stocks[101, c("honda")]) )
+fc <- forecast(fit, ahead = 2, xC = cbind(stocks[101:102, c("honda")], stocks[101:102, c("honda")]) ,inc_samples = TRUE)
 fc
 
 lfo <- loo(fit, mode = 'backward',  L = 80 )


### PR DESCRIPTION
Added inc_warmup option to forecast and fitted.

- Defaults to FALSE
- When TRUE, forecast(fit, ...)$forecast$samples is a list containing the samples of mean, var, and cor.
- Likewise with fitted(fit, ...)$backcast$samples