### PR TITLE
Forecasting fix

### DIFF
--- a/R/forecasting_gq.R
+++ b/R/forecasting_gq.R
@@ -193,13 +193,13 @@ forecast.bmgarch <- function(object, ahead = 1, xC = NULL,
     })
 
     ## Init f.mean
-    f.mean <- .get_stan_summary(object.f, "rts_p", CrI, weights)
+    f.mean <- .get_stan_summary(object.f, "rts_forecasted", CrI, weights)
 
     ## f.var
-    f.var <- .get_stan_summary(object.f, "H_p", CrI, weights)
+    f.var <- .get_stan_summary(object.f, "H_forecasted", CrI, weights)
 
     ## Init f.cor
-    f.cor <- .get_stan_summary(object.f, "R_p", CrI, weights)
+    f.cor <- .get_stan_summary(object.f, "R_forecasted", CrI, weights)
 
     # Restructure to array
     backcast <- max(object[[1]]$mgarchP, object[[1]]$mgarchQ)

--- a/R/forecasting_gq.R
+++ b/R/forecasting_gq.R
@@ -202,25 +202,25 @@ forecast.bmgarch <- function(object, ahead = 1, xC = NULL,
     f.cor <- .get_stan_summary(object.f, "R_forecasted", CrI, weights)
 
     # Restructure to array
-    backcast <- max(object[[1]]$mgarchP, object[[1]]$mgarchQ)
+    ## backcast <- max(object[[1]]$mgarchP, object[[1]]$mgarchQ)
     nt <- object[[1]]$nt
-    cast_start <- (object[[1]]$TS_length - backcast + 1)
+    ## cast_start <- (object[[1]]$TS_length - backcast + 1)
     forecast_start <- (object[[1]]$TS_length + 1)
     forecast_end <- (object[[1]]$TS_length + ahead)
 
     ## f.mean
     stan_sum_cols <- colnames(f.mean)
-    f.mean <- array(f.mean, dim = c(nt, backcast + ahead, ncol(f.mean)))
+    f.mean <- array(f.mean, dim = c(nt, ahead, ncol(f.mean)))
     f.mean <- aperm(f.mean, c(2,3,1))
-    dimnames(f.mean) <- list(period = cast_start:forecast_end, stan_sum_cols, TS = TS_names)
+    dimnames(f.mean) <- list(period = forecast_start:forecast_end, stan_sum_cols, TS = TS_names)
 
     ## f.var
     ### Pull out indices for [period, a, a]
-    f.var.indices <- grep("H_p\\[[[:digit:]]+,([[:digit:]]+),\\1]", rownames(f.var), value = TRUE)
+    f.var.indices <- grep("H_forecasted\\[[[:digit:]]+,([[:digit:]]+),\\1]", rownames(f.var), value = TRUE)
     f.var <- f.var[f.var.indices,]
-    f.var <- array(f.var, dim = c(nt, backcast + ahead, ncol(f.var)))
+    f.var <- array(f.var, dim = c(nt, ahead, ncol(f.var)))
     f.var <- aperm(f.var, c(2, 3, 1))
-    dimnames(f.var) <- list(period = cast_start:forecast_end, stan_sum_cols, TS = TS_names)
+    dimnames(f.var) <- list(period = forecast_start:forecast_end, stan_sum_cols, TS = TS_names)
 
     ## f.cor
     # Lower-triangular indices
@@ -230,17 +230,17 @@ forecast.bmgarch <- function(object, ahead = 1, xC = NULL,
     # Indices as "a,b"
     f.cor.indices.L.char <- paste0(f.cor.indices.L[, 1], ",", f.cor.indices.L[,2])
     # Indicices as "[period,a,b]"
-    f.cor.indices.L.all <- paste0("R_p[",1:(backcast + ahead), ",", rep(f.cor.indices.L.char, each = (backcast + ahead)),"]")
+    f.cor.indices.L.all <- paste0("R_forecasted[",1:(ahead), ",", rep(f.cor.indices.L.char, each = (ahead)),"]")
     # Get only these elements.
     f.cor <- f.cor[f.cor.indices.L.all,]
-    f.cor <- array(f.cor, dim = c(backcast + ahead, length(f.cor.indices.L.char), ncol(f.cor)))
+    f.cor <- array(f.cor, dim = c(ahead, length(f.cor.indices.L.char), ncol(f.cor)))
     f.cor <- aperm(f.cor, c(1, 3, 2))
-    dimnames(f.cor) <- list(period = cast_start:forecast_end, stan_sum_cols, TS = f.cor.indices.L.labels)
+    dimnames(f.cor) <- list(period = forecast_start:forecast_end, stan_sum_cols, TS = f.cor.indices.L.labels)
 
     # Remove backcasts from forecasts.
-    f.mean <- f.mean[-c(1:backcast), , , drop = FALSE]
-    f.var <- f.var[-c(1:backcast), , , drop = FALSE]
-    f.cor <- f.cor[-c(1:backcast), , , drop = FALSE]
+    ## f.mean <- f.mean[-c(1:backcast), , , drop = FALSE]
+    ## f.var <- f.var[-c(1:backcast), , , drop = FALSE]
+    ## f.cor <- f.cor[-c(1:backcast), , , drop = FALSE]
    
     out <- list()
     out$forecast$mean <- f.mean
@@ -249,9 +249,9 @@ forecast.bmgarch <- function(object, ahead = 1, xC = NULL,
     out$forecast$meta <- list(xC = xC, TS_length = ahead)
 
     if(inc_samples) {
-        out$forecast$samples$mean <- .weighted_samples(object.f, "rts_p", weights)$rts_p[, -c(1:backcast),, drop = FALSE]
-        out$forecast$samples$var <- .weighted_samples(object.f, "H_p", weights)$H_p[,-c(1:backcast), , , drop = FALSE]
-        out$forecast$samples$cor <- .weighted_samples(object.f, "R_p", weights)$R_p[,-c(1:backcast), , , drop = FALSE]
+        out$forecast$samples$mean <- .weighted_samples(object.f, "rts_forecasted", weights)$rts_forecasted[, ,, drop = FALSE]
+        out$forecast$samples$var <- .weighted_samples(object.f, "H_forecasted", weights)$H_forecasted[,, , , drop = FALSE]
+        out$forecast$samples$cor <- .weighted_samples(object.f, "R_forecasted", weights)$R_forecasted[,, , , drop = FALSE]
         ## out$forecast$samples$mean <- out$forecast$samples$mean[] # Todo, remove backcast
     }
 

--- a/src/stan_files/forecastBEKK.stan
+++ b/src/stan_files/forecastBEKK.stan
@@ -49,9 +49,12 @@ parameters {
 generated quantities {
   // Define matrix for rts prediction
   vector[nt] rts_p[ahead + max(Q,P)];
+  vector[nt] rts_forecasted[ahead];
   
   cov_matrix[nt] H_p[ahead + max(Q,P)];
   corr_matrix[nt] R_p[ahead + max(Q,P)];
+  cov_matrix[nt] H_forecasted[ahead];
+  corr_matrix[nt] R_forecasted[ahead];
 
   matrix[nt,nt] rr_p[ahead + max(Q,P)];
   vector[nt] mu_p[ahead + max(Q,P)];
@@ -129,4 +132,7 @@ generated quantities {
     /*   } */
     /* } */
   }
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }

--- a/src/stan_files/forecastBEKK.stan
+++ b/src/stan_files/forecastBEKK.stan
@@ -58,6 +58,7 @@ generated quantities {
 
   matrix[nt,nt] rr_p[ahead + max(Q,P)];
   vector[nt] mu_p[ahead + max(Q,P)];
+  vector[nt] mu_forecasted[ahead];
 
   matrix[nt+1, nt] beta = append_row( beta0, diag_matrix(beta1) );
 
@@ -135,4 +136,6 @@ generated quantities {
   rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+#include /generated/forecast_log_lik.stan
 }

--- a/src/stan_files/forecastBEKK.stan
+++ b/src/stan_files/forecastBEKK.stan
@@ -132,7 +132,7 @@ generated quantities {
     /*   } */
     /* } */
   }
-  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }

--- a/src/stan_files/forecastCCC.stan
+++ b/src/stan_files/forecastCCC.stan
@@ -130,7 +130,7 @@ generated quantities {
     /*   } */
     /* } */
   }
-  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }

--- a/src/stan_files/forecastCCC.stan
+++ b/src/stan_files/forecastCCC.stan
@@ -51,6 +51,7 @@ generated quantities {
   
   // Define Vector that contains max of Q or P lag plus the forecasted ahead
   vector[nt] mu_p[ahead + max(Q,P)];
+  vector[nt] mu_forecasted[ahead];
   // Define matrix for rts prediction
   vector[nt] rts_p[ahead + max(Q,P)];
   vector[nt] rts_forecasted[ahead];
@@ -133,5 +134,7 @@ generated quantities {
   rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+#include /generated/forecast_log_lik.stan
 }
 

--- a/src/stan_files/forecastCCC.stan
+++ b/src/stan_files/forecastCCC.stan
@@ -44,13 +44,16 @@ generated quantities {
   // Params for prediction
   vector[nt] D_p[ahead + max(Q,P)];
   corr_matrix[nt] R_p[ahead + max(Q, P)] = rep_array(R, ahead + max(Q, P)); // R_p = R for all t.
+  corr_matrix[nt] R_forecasted[ahead] = rep_array(R, ahead);
 
   cov_matrix[nt] H_p[ahead + max(Q,P)];
+  cov_matrix[nt] H_forecasted[ahead];
   
   // Define Vector that contains max of Q or P lag plus the forecasted ahead
   vector[nt] mu_p[ahead + max(Q,P)];
   // Define matrix for rts prediction
   vector[nt] rts_p[ahead + max(Q,P)];
+  vector[nt] rts_forecasted[ahead];
   vector[nt] rr_p[ahead + max(Q,P)];
 
   // log lik for LFO-CV
@@ -127,5 +130,8 @@ generated quantities {
     /*   } */
     /* } */
   }
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }
 

--- a/src/stan_files/forecastDCC.stan
+++ b/src/stan_files/forecastDCC.stan
@@ -149,7 +149,7 @@ generated quantities {
     /* 	  } */
     /* } */
   }
-  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }

--- a/src/stan_files/forecastDCC.stan
+++ b/src/stan_files/forecastDCC.stan
@@ -46,8 +46,11 @@ parameters {
 generated quantities {
   // Define matrix for rts prediction
   vector[nt] rts_p[ahead + max(Q,P)];
+  vector[nt] rts_forecasted[ahead];
   cov_matrix[nt] H_p[ahead + max(Q,P)];
+  cov_matrix[nt] H_forecasted[ahead];
   corr_matrix[nt] R_p[ahead + max(Q,P)]; // 
+  corr_matrix[nt] R_forecasted[ahead]; // 
   vector[nt] rr_p[ahead + max(Q,P)];
   vector[nt] mu_p[ahead + max(Q,P)];
   vector[nt] D_p[ahead + max(Q,P)];
@@ -146,4 +149,7 @@ generated quantities {
     /* 	  } */
     /* } */
   }
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
 }

--- a/src/stan_files/forecastDCC.stan
+++ b/src/stan_files/forecastDCC.stan
@@ -53,6 +53,7 @@ generated quantities {
   corr_matrix[nt] R_forecasted[ahead]; // 
   vector[nt] rr_p[ahead + max(Q,P)];
   vector[nt] mu_p[ahead + max(Q,P)];
+  vector[nt] mu_forecasted[ahead];
   vector[nt] D_p[ahead + max(Q,P)];
   cov_matrix[nt] Qr_p[ahead + max(Q,P)];
   vector[nt] u_p[ahead + max(Q,P)];
@@ -152,4 +153,6 @@ generated quantities {
   rts_forecasted = rts_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   H_forecasted = H_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
   R_forecasted = R_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+  mu_forecasted = mu_p[max(Q, P) + 1 : (max(Q, P) + ahead)];
+#include /generated/forecast_log_lik.stan
 }

--- a/src/stan_files/generated/forecast_log_lik.stan
+++ b/src/stan_files/generated/forecast_log_lik.stan
@@ -1,0 +1,11 @@
+if( compute_log_lik ) {
+  if (distribution == 0 ) {
+    for(i in 1:ahead) {
+      log_lik[i] = multi_normal_lpdf( future_rts[i] | mu_forecasted[i], H_forecasted[i]);
+    }
+  } else if (distribution == 1 ) {
+    for(i in 1:ahead) {
+      log_lik[i] = multi_student_t_lpdf( future_rts[i] | nu, mu_forecasted[i], H_forecasted[i]);
+    }
+  }
+ }

--- a/src/stan_files/generated/forecast_sampling.stan
+++ b/src/stan_files/generated/forecast_sampling.stan
@@ -1,15 +1,5 @@
 if ( distribution == 0 ) {
   rts_p[t,] = multi_normal_rng( mu_p[t,], H_p[t,]);
-  if( compute_log_lik ) {
-    for( i in 1:ahead ){
-      log_lik[i] = multi_normal_lpdf( future_rts[i] |  mu_p[t,], H_p[t,] );
-    }
-  }
  } else if ( distribution == 1 ) {
   rts_p[t,] = multi_student_t_rng( nu, mu_p[t,], H_p[t,]);
-  if( compute_log_lik ) {
-    for( i in 1:ahead ){
-      log_lik[i] = multi_student_t_lpdf( future_rts[i] | nu, mu_p[t,], H_p[t,] );
-    }
-  }
  }

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -48,13 +48,26 @@ sr2
 r2
 
 fit <- bmgarch(sr2,
-               iterations = 1000,
+               iterations = 20,
                P = 1, Q = 1,
                meanstructure = "arma",
                standardize_data = FALSE,
                parameterization = 'DCC',
                xH = NULL,
                adapt_delta=0.85)
+fit2 <- bmgarch(sr2,
+               iterations = 20,
+               P = 2, Q = 1,
+               meanstructure = "arma",
+               standardize_data = FALSE,
+               parameterization = 'DCC',
+               xH = NULL,
+               adapt_delta=0.85)
+
+bmList <- bmgarch_list(fit, fit2)
+wts <- model_weights(bmList, L = 90)
+fcOut <- forecast(bmList, ahead = 3, weights = wts)
+
 system("notify-send 'Done sampling' " )
 summary(fit )
 


### PR DESCRIPTION
This patchset fixes the dimensionality problem: When forecasting from bmgarch_list, and models contain different P/Q configurations, the forecast-gqs samples are of different dimensions. Therefore, the weighted samples cannot be computed (non-conformant arrays).

- Changed forecast stan models to return only {rts, R, H}_forecasted
- *_forecasted contains only the forecasted values (the ahead values).
- Updated the forecast.bmgarch method to remove references to backcast and cast_start, as these are no longer required. No need to drop samples nor summary output, because the stan models produce the desired ahead lengths (rather than ahead + max(P,Q)).

Tested [P,Q, type]: 
- Model 1 [1, 1, DCC] vs Model 2 [2, 1, DCC]: Ahead 3
- Model 1 [1, 1, DCC] vs Model 2[2, 3, DCC]: Ahead 3

Need to test CCC, BEKK, pdBEKK.

EDIT: Added fix for log_lik for P, Q > 1. Only tested for errors; did not test for correctness. No errors occurred in [1, 1, DCC] vs [2, 3, DCC]: Ahead 3, with or without inc_samples.