### PR TITLE
DCC/CCC sum constraints to allow higher P,Q without init problems.

### DIFF
--- a/src/stan_files/CCCMGARCH.stan
+++ b/src/stan_files/CCCMGARCH.stan
@@ -34,7 +34,9 @@ parameters {
 
   // GARCH h parameters on variance metric
   vector[nt] c_h; 
-  vector<lower=0, upper = 1 >[nt] a_h[Q];
+  // vector<lower=0, upper = 1 >[nt] a_h[Q];
+  simplex[Q] a_h_simplex[nt];
+  vector<lower=0, upper = 1>[nt] a_h_limit;
   simplex[P] b_h_simplex[nt];
   vector[nt] b_h_limit_s;
   // vector<lower=0, upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
@@ -57,6 +59,7 @@ transformed parameters {
   real<lower = 0> vd[nt];
   real<lower = 0> ma_d[nt];
   real<lower = 0> ar_d[nt];
+  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_limit);
   vector[nt] UPs = upper_limits(a_h);
   vector[nt] ULs = raw_limit_to_b_h_limit(b_h_limit_s, UPs);
   vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);

--- a/src/stan_files/CCCMGARCH.stan
+++ b/src/stan_files/CCCMGARCH.stan
@@ -36,9 +36,9 @@ parameters {
   vector[nt] c_h; 
   // vector<lower=0, upper = 1 >[nt] a_h[Q];
   simplex[Q] a_h_simplex[nt];
-  vector<lower=0, upper = 1>[nt] a_h_limit;
+  vector<lower=0, upper = 1>[nt] a_h_sum;
   simplex[P] b_h_simplex[nt];
-  vector[nt] b_h_limit_s;
+  vector[nt] b_h_sum_s;
   // vector<lower=0, upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
 
   // GARCH constant correlation 
@@ -59,9 +59,9 @@ transformed parameters {
   real<lower = 0> vd[nt];
   real<lower = 0> ma_d[nt];
   real<lower = 0> ar_d[nt];
-  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_limit);
+  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_sum);
   vector[nt] UPs = upper_limits(a_h);
-  vector[nt] ULs = raw_limit_to_b_h_limit(b_h_limit_s, UPs);
+  vector[nt] ULs = raw_sum_to_b_h_sum(b_h_sum_s, UPs);
   vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);
   // Initialize t=1
   // Check "Order Sensitivity and Repeated Variables" in stan reference manual
@@ -103,7 +103,7 @@ model {
   // priors
   for(k in 1:nt) {
     ULs[k] ~ uniform(0, UPs[k]);
-    target += a_b_scale_jacobian(0, ULs[k], b_h_limit_s[k]);
+    target += a_b_scale_jacobian(0, ULs[k], b_h_sum_s[k]);
   }
   to_vector(beta) ~ normal(0, 1);
   to_vector(c_h) ~ normal(-2, 4);

--- a/src/stan_files/DCCMGARCH.stan
+++ b/src/stan_files/DCCMGARCH.stan
@@ -37,7 +37,9 @@ parameters {
 
   // GARCH h parameters on variance metric
   vector[nt] c_h; // variance on log metric 
-  vector<lower = 0,  upper = 1 >[nt] a_h[Q];
+  // vector<lower = 0,  upper = 1 >[nt] a_h[Q];
+  simplex[Q] a_h_simplex[nt];
+  vector<lower=0, upper = 1>[nt] a_h_limit;
   simplex[P] b_h_simplex[nt]; // Simplex for b_h within each timeseries
   vector[nt] b_h_limit_s; // Raw upper limiter. b_h[i] = U[i] b_h_simplex[i]; U[i] ~ U(0, sum(a_h[i]))
   // vector<lower = 0,  upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
@@ -68,6 +70,7 @@ transformed parameters {
   real<lower = 0> vd[nt];
   real<lower = 0> ma_d[nt];
   real<lower = 0> ar_d[nt];  
+  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_limit);
   vector[nt] UPs = upper_limits(a_h);
   vector[nt] ULs = raw_limit_to_b_h_limit(b_h_limit_s, UPs);
   vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);

--- a/src/stan_files/DCCMGARCH.stan
+++ b/src/stan_files/DCCMGARCH.stan
@@ -1,6 +1,7 @@
 // DCC-Parameterization
 functions { 
 #include /functions/cov2cor.stan
+#include /functions/jacobian.stan
 }
 
 data {
@@ -37,7 +38,9 @@ parameters {
   // GARCH h parameters on variance metric
   vector[nt] c_h; // variance on log metric 
   vector<lower = 0,  upper = 1 >[nt] a_h[Q];
-  vector<lower = 0,  upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
+  simplex[P] b_h_simplex[nt]; // Simplex for b_h within each timeseries
+  vector[nt] b_h_limit_s; // Raw upper limiter. b_h[i] = U[i] b_h_simplex[i]; U[i] ~ U(0, sum(a_h[i]))
+  // vector<lower = 0,  upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
   // GARCH q parameters 
   real<lower=0, upper = 1 > a_q; // 
   real<lower=0, upper = (1 - a_q) > b_q; //
@@ -65,6 +68,15 @@ transformed parameters {
   real<lower = 0> vd[nt];
   real<lower = 0> ma_d[nt];
   real<lower = 0> ar_d[nt];  
+  vector[nt] UPs = upper_limits(a_h);
+  vector[nt] ULs = raw_limit_to_b_h_limit(b_h_limit_s, UPs);
+  vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);
+  // vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex,
+  // 							  raw_limit_to_b_h_limit(b_h_limit_s,
+  // 										 upper_limits(a_h)
+  // 										 )
+  // 							  );
+  // print("b_h:", b_h);
 
   // Initialize t=1
   mu[1,] = phi0;
@@ -89,12 +101,12 @@ transformed parameters {
 	rr[t-q, d] = square( rts[t-q, d] - mu[t-q, d] );
 	ma_d[d] = ma_d[d] + a_h[q, d]*rr[t-q, d] ;
       }
-      print("ma_d: ", "TS:", d, " Value:", ma_d[d], " T:", t);
+      // print("ma_d: ", "TS:", d, " Value:", ma_d[d], " T:", t);
       // GARCH AR component
       for (p in 1:min( t-1, P) ) {
 	ar_d[d] = ar_d[d] + b_h[p, d]*D[t-p, d]^2;
       }
-      print("ar_d: ", "TS:", d, " Value:", ar_d[d], " T:", t);
+      // print("ar_d: ", "TS:", d, " Value:", ar_d[d], " T:", t);
 
       // Predictor on diag (given in xC)
       if ( xC_marker >= 1) {
@@ -102,12 +114,12 @@ transformed parameters {
       } else if ( xC_marker == 0) {
       	vd[d] = exp( c_h[d] )  + ma_d[d] + ar_d[d];
       }
-      print("c_h: ", "TS: ", d, " Value:", c_h[d]);
+      // print("c_h: ", "TS: ", d, " Value:", c_h[d]);
 
       D[t, d] = sqrt( vd[d] );
     }
     u[t,] = diag_matrix(D[t,]) \ (rts[t,]- mu[t,]); // cf. comment about taking inverses in stan manual p. 482 re:Inverses - inv(D)*y = D \ a
-    print("u: ", "Value: ", u[t], "T:", t);
+    // print("u: ", "Value: ", u[t], "T:", t);
     Qr[t,] = (1 - a_q - b_q) * S + a_q * (u[t-1,] * u[t-1,]') + b_q * Qr[t-1,]; // S and UU' define dimension of Qr
     Qr_sdi[t,] = 1 ./ sqrt(diagonal(Qr[t,])); // inverse of diagonal matrix of sd's of Qr
     //    R[t,] = quad_form_diag(Qr[t,], inv(sqrt(diagonal(Qr[t,]))) ); // Qr_sdi[t,] * Qr[t,] * Qr_sdi[t,];
@@ -116,6 +128,13 @@ transformed parameters {
   }
 }
 model {
+  // print("Upper Limits:", UPs);
+  // UL transform jacobian
+  for(k in 1:nt) {
+    ULs[k] ~ uniform(0, UPs[k]); // Truncation not needed.
+    target += a_b_scale_jacobian(0, ULs[k], b_h_limit_s[k]);
+  }
+
   // priors
   to_vector(beta) ~ std_normal();
   to_vector(c_h) ~ std_normal();

--- a/src/stan_files/DCCMGARCH.stan
+++ b/src/stan_files/DCCMGARCH.stan
@@ -39,9 +39,9 @@ parameters {
   vector[nt] c_h; // variance on log metric 
   // vector<lower = 0,  upper = 1 >[nt] a_h[Q];
   simplex[Q] a_h_simplex[nt];
-  vector<lower=0, upper = 1>[nt] a_h_limit;
+  vector<lower=0, upper = 1>[nt] a_h_sum;
   simplex[P] b_h_simplex[nt]; // Simplex for b_h within each timeseries
-  vector[nt] b_h_limit_s; // Raw upper limiter. b_h[i] = U[i] b_h_simplex[i]; U[i] ~ U(0, sum(a_h[i]))
+  vector[nt] b_h_sum_s; // Unconstrained b_h_sum values. b_h[i] = U[i] b_h_simplex[i]; U[i] ~ U(0, 1 - sum(a_h[i]))
   // vector<lower = 0,  upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
   // GARCH q parameters 
   real<lower=0, upper = 1 > a_q; // 
@@ -70,9 +70,9 @@ transformed parameters {
   real<lower = 0> vd[nt];
   real<lower = 0> ma_d[nt];
   real<lower = 0> ar_d[nt];  
-  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_limit);
+  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_sum);
   vector[nt] UPs = upper_limits(a_h);
-  vector[nt] ULs = raw_limit_to_b_h_limit(b_h_limit_s, UPs);
+  vector[nt] ULs = raw_sum_to_b_h_sum(b_h_sum_s, UPs);
   vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);
   // vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex,
   // 							  raw_limit_to_b_h_limit(b_h_limit_s,
@@ -135,7 +135,7 @@ model {
   // UL transform jacobian
   for(k in 1:nt) {
     ULs[k] ~ uniform(0, UPs[k]); // Truncation not needed.
-    target += a_b_scale_jacobian(0, ULs[k], b_h_limit_s[k]);
+    target += a_b_scale_jacobian(0, ULs[k], b_h_sum_s[k]);
   }
 
   // priors

--- a/src/stan_files/DCCMGARCH.stan
+++ b/src/stan_files/DCCMGARCH.stan
@@ -89,10 +89,12 @@ transformed parameters {
 	rr[t-q, d] = square( rts[t-q, d] - mu[t-q, d] );
 	ma_d[d] = ma_d[d] + a_h[q, d]*rr[t-q, d] ;
       }
+      print("ma_d: ", "TS:", d, " Value:", ma_d[d], " T:", t);
       // GARCH AR component
       for (p in 1:min( t-1, P) ) {
 	ar_d[d] = ar_d[d] + b_h[p, d]*D[t-p, d]^2;
       }
+      print("ar_d: ", "TS:", d, " Value:", ar_d[d], " T:", t);
 
       // Predictor on diag (given in xC)
       if ( xC_marker >= 1) {
@@ -100,10 +102,12 @@ transformed parameters {
       } else if ( xC_marker == 0) {
       	vd[d] = exp( c_h[d] )  + ma_d[d] + ar_d[d];
       }
+      print("c_h: ", "TS: ", d, " Value:", c_h[d]);
 
       D[t, d] = sqrt( vd[d] );
     }
     u[t,] = diag_matrix(D[t,]) \ (rts[t,]- mu[t,]); // cf. comment about taking inverses in stan manual p. 482 re:Inverses - inv(D)*y = D \ a
+    print("u: ", "Value: ", u[t], "T:", t);
     Qr[t,] = (1 - a_q - b_q) * S + a_q * (u[t-1,] * u[t-1,]') + b_q * Qr[t-1,]; // S and UU' define dimension of Qr
     Qr_sdi[t,] = 1 ./ sqrt(diagonal(Qr[t,])); // inverse of diagonal matrix of sd's of Qr
     //    R[t,] = quad_form_diag(Qr[t,], inv(sqrt(diagonal(Qr[t,]))) ); // Qr_sdi[t,] * Qr[t,] * Qr_sdi[t,];
@@ -117,7 +121,7 @@ model {
   to_vector(c_h) ~ std_normal();
   // Prior for initial state
   Qr1_init ~ wishart(nt + 1.0, diag_matrix(rep_vector(1.0, nt)) );
-  to_vector(D1_init) ~ lognormal(0, 1);
+  to_vector(D1_init) ~ lognormal(-1, 1);
   to_vector(u1_init) ~ std_normal();
   // Prior on nu for student_t
   //if ( distribution == 1 )

--- a/src/stan_files/functions/jacobian.stan
+++ b/src/stan_files/functions/jacobian.stan
@@ -1,13 +1,33 @@
+/*
+  Computes jacobian for the a_b_scale transform.
+  @param a Lower limit.
+  @param b Upper limit.
+  @param value The unconstrained value to be transformed.
+  @return log jacobian contribution.
+ */
 real a_b_scale_jacobian(real a, real b, real value) {
   real invlogit_value = inv_logit(value);
   real out = log(b - a) + log(invlogit_value) + log1m(invlogit_value);
   return(out);
 }
 
+/*
+  Takes unconstrained R value, transforms to be between a and b.
+  @param a Lower limit.
+  @param b Upper limit.
+  @param value The unconstrained value to transform
+  @return real value between a and b.
+ */
 real a_b_scale(real a, real b, real value) {
   return(a + (b - a) * inv_logit(value));
 }
 
+/*
+  Compute the upper limit of b_h from a_h, given that sum(a_h) + sum(b_h) < 1
+  This works for b_h given a_h, or a_h given b_h. They yield identical models, assuming a dual constraint, such that 0 < sum(a_h) < 1 and 0 < sum(b_h) < 1 - sum(a_h), or vice-versa.
+  @param a_h Array of vectors [nt, Q].
+  @return vector[nt] Upper limits such that sum(b_h{k}) < UpperLimit{k} = 1 - sum(a_h{k})
+ */
 vector upper_limits(vector[] a_h) {
   int nt = num_elements(a_h[1]);
   int Q = size(a_h);
@@ -21,20 +41,39 @@ vector upper_limits(vector[] a_h) {
 
   return(out);
 }
-vector raw_limit_to_b_h_limit(vector b_h_limit_s, vector upperLimits) {
+
+/*
+  Transform unconstrained sums to (0, upperLimits).
+  @param b_h_sum_s A vector [nt] of unconstrained sums.
+  @param upperLimits A vector [nt] of the upper limits.
+  @return vector[nt] of values between [0, upperLimits].
+ */
+vector raw_sum_to_b_h_sum(vector b_h_sum_s, vector upperLimits) {
   int nt = num_elements(upperLimits);
   vector[nt] out;
   for(k in 1:nt) {
-    out[k] = a_b_scale(0, upperLimits[k], b_h_limit_s[k]);
+    out[k] = a_b_scale(0, upperLimits[k], b_h_sum_s[k]);
   }
   return(out);
 }
-vector[] simplex_to_bh(vector[] b_h_simplex, vector b_h_limit) {
+/*
+  Transform the array of b_h simplexes to b_h.
+  
+  The dual constraint is such that 0 < sum(a_h) + sum(b_h) < 1, for each timeseries.
+  We assume sum(a_h) is [0,1], then sum(b_h) is [0, 1 - sum(a_h)].
+  The sums are estimated for a_h and b_h.
+  Then the a_h and b_h simplexes are scaled by the sums to produce a_h and b_h.
+
+  @param b_h_simplex Array [nt] of simplexes [P].
+  @param b_h_sum vector [nt] of the value to which the b_h's should be summed.
+  @return An array [P] of vectors [nt].
+ */
+vector[] simplex_to_bh(vector[] b_h_simplex, vector b_h_sum) {
   int nt = size(b_h_simplex);
   int P = num_elements(b_h_simplex[1]);
   vector[nt] b_h[P];
   for(k in 1:nt) {
-    b_h[1:P, k] = to_array_1d(b_h_simplex[k] * b_h_limit[k]);
+    b_h[1:P, k] = to_array_1d(b_h_simplex[k] * b_h_sum[k]);
   }
   return(b_h);
 }

--- a/src/stan_files/functions/jacobian.stan
+++ b/src/stan_files/functions/jacobian.stan
@@ -1,0 +1,40 @@
+real a_b_scale_jacobian(real a, real b, real value) {
+  real invlogit_value = inv_logit(value);
+  real out = log(b - a) + log(invlogit_value) + log1m(invlogit_value);
+  return(out);
+}
+
+real a_b_scale(real a, real b, real value) {
+  return(a + (b - a) * inv_logit(value));
+}
+
+vector upper_limits(vector[] a_h) {
+  int nt = num_elements(a_h[1]);
+  int Q = size(a_h);
+  vector[nt] a_h_sums;
+  vector[nt] out;
+  for(k in 1:nt) {
+    a_h_sums[k] = sum(a_h[1:Q, k]);
+    out[k] = 1 - a_h_sums[k];
+    if(out[k] <= 0) {out[k] = .00001;}
+  }
+
+  return(out);
+}
+vector raw_limit_to_b_h_limit(vector b_h_limit_s, vector upperLimits) {
+  int nt = num_elements(upperLimits);
+  vector[nt] out;
+  for(k in 1:nt) {
+    out[k] = a_b_scale(0, upperLimits[k], b_h_limit_s[k]);
+  }
+  return(out);
+}
+vector[] simplex_to_bh(vector[] b_h_simplex, vector b_h_limit) {
+  int nt = size(b_h_simplex);
+  int P = num_elements(b_h_simplex[1]);
+  vector[nt] b_h[P];
+  for(k in 1:nt) {
+    b_h[1:P, k] = to_array_1d(b_h_simplex[k] * b_h_limit[k]);
+  }
+  return(b_h);
+}

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -49,10 +49,10 @@ r2
 
 fit <- bmgarch(sr2,
                iterations = 500,
-               P = 2, Q = 3,
+               P = 1, Q = 1,
                meanstructure = "arma",
                standardize_data = FALSE,
-               parameterization = 'CCC', # Fails on CCC(>3,3)
+               parameterization = 'DCC', # Fails on CCC(>3,3)
                xH = NULL,
                adapt_delta=0.85)
 
@@ -64,6 +64,18 @@ fit2 <- bmgarch(sr2,
                parameterization = 'pdBEKK',
                xH = NULL,
                adapt_delta=0.85)
+
+fit.stocks.DCC <- bmgarch(stocks[1:100, c("toyota", "nissan", "honda")],
+                          P = 2, Q = 3,
+                          meanstructure = "arma",
+                          parameterization = "DCC",
+                          iterations = 500)
+
+fit.stocks.CCC <- bmgarch(stocks[1:100, c("toyota", "nissan", "honda")],
+                          P = 2, Q = 2,
+                          meanstructure = "arma",
+                          parameterization = "CCC",
+                          iterations = 500)
 
 bmList <- bmgarch_list(fit, fit2)
 wts <- model_weights(bmList, L = 90)

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -48,8 +48,8 @@ sr2
 r2
 
 fit <- bmgarch(sr2,
-               iterations = 20,
-               P = 4, Q = 4,
+               iterations = 500,
+               P = 2, Q = 3,
                meanstructure = "arma",
                standardize_data = FALSE,
                parameterization = 'DCC', # Fails on CCC(>3,3)

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -52,7 +52,7 @@ fit <- bmgarch(sr2,
                P = 2, Q = 3,
                meanstructure = "arma",
                standardize_data = FALSE,
-               parameterization = 'DCC', # Fails on CCC(>3,3)
+               parameterization = 'CCC', # Fails on CCC(>3,3)
                xH = NULL,
                adapt_delta=0.85)
 

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -49,18 +49,19 @@ r2
 
 fit <- bmgarch(sr2,
                iterations = 20,
-               P = 1, Q = 1,
+               P = 4, Q = 4,
                meanstructure = "arma",
                standardize_data = FALSE,
-               parameterization = 'DCC',
+               parameterization = 'DCC', # Fails on CCC(>3,3)
                xH = NULL,
                adapt_delta=0.85)
+
 fit2 <- bmgarch(sr2,
                iterations = 20,
-               P = 2, Q = 1,
+               P = 4, Q = 4,
                meanstructure = "arma",
                standardize_data = FALSE,
-               parameterization = 'DCC',
+               parameterization = 'pdBEKK',
                xH = NULL,
                adapt_delta=0.85)
 

--- a/tests/fin_ts.R
+++ b/tests/fin_ts.R
@@ -65,8 +65,23 @@ fit2 <- bmgarch(sr2,
                xH = NULL,
                adapt_delta=0.85)
 
+data(stocks)
+stocks[,3:5] <- scale(stocks[,3:5])
+
 fit.stocks.DCC <- bmgarch(stocks[1:100, c("toyota", "nissan", "honda")],
-                          P = 2, Q = 3,
+                          P = 4, Q = 5,
+                          meanstructure = "arma",
+                          parameterization = "DCC",
+                          iterations = 500)
+
+fit.stocks.DCC2 <- bmgarch(stocks[1:100, c("toyota", "nissan", "honda")],
+                          P = 4, Q = 1,
+                          meanstructure = "arma",
+                          parameterization = "DCC",
+                          iterations = 500)
+
+fit.stocks.DCC3 <- bmgarch(stocks[1:100, c("toyota", "nissan", "honda")],
+                          P = 1, Q = 4,
                           meanstructure = "arma",
                           parameterization = "DCC",
                           iterations = 500)


### PR DESCRIPTION
Added dual-constraint on DCC/CCC a_h and b_h parameters.

Dual constraint:
For a given timeseries,

0 < sum_q(a_h) + sum_p(b_h) < 1 [Required, target constraint]

0 < sum(a_h) < 1 [Constraint 1]

0 < sum(b_h) < 1 - sum(a_h) [Constraint 2]

The dual constraint is that a sum-constraint is imposed on both a_h and b_h.

This is achieved through estimating a_h and b_h, for each time series, as simplex (0, 1; summing to 1). These are then scaled by the estimated sum(a_h) and sum(b_h) values, each constrained such that <lower=0, upper=1> sum(a_h); and <lower=0, upper = 1 - sum(a_h)> sum(b_h). 

This satisfies the required constraints, and permits P,Q of any size without initialization problems.