### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     loo,
     MASS,
     Rdpack,
-    rstan (>= 2.19.2),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1)
 LinkingTo: 
     BH (>= 1.72.0-0),
@@ -33,8 +33,8 @@ LinkingTo:
     RcppParallel (>= 5.0.1),
     RcppEigen (>= 0.3.3.7.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.19.2),
-    StanHeaders (>= 2.21.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 RdMacros: Rdpack
 Encoding: UTF-8
 LazyData: true

--- a/inst/stan/BEKKMGARCH.stan
+++ b/inst/stan/BEKKMGARCH.stan
@@ -42,8 +42,8 @@ parameters {
   // C_sd is defined in tp, as function of betas
   corr_matrix[nt] C_R;
 
-  matrix[nt, nt] A_raw[Q];
-  matrix[nt, nt] B_raw[P];
+  array[Q] matrix[nt, nt] A_raw;
+  array[P] matrix[nt, nt] B_raw;
 
     // H1 init
   cov_matrix[nt] H1_init; 
@@ -51,9 +51,9 @@ parameters {
 
 }
 transformed parameters {
-  cov_matrix[nt] H[T];
-  matrix[nt,nt] rr[T-1];
-  vector[nt] mu[T];
+  array[T] cov_matrix[nt] H;
+  array[T-1] matrix[nt,nt] rr;
+  array[T] vector[nt] mu;
 
   matrix[nt, nt] A_part = diag_matrix( rep_vector(0.0, nt));
   matrix[nt, nt] B_part = diag_matrix( rep_vector(0.0, nt));
@@ -131,12 +131,12 @@ model {
 }
 //
 generated quantities {
-  matrix[nt, nt] A[Q] = A_raw;
-  matrix[nt, nt] B[P] = B_raw;
+  array[Q] matrix[nt, nt] A = A_raw;
+  array[P] matrix[nt, nt] B = B_raw;
   matrix[nt,T] rts_out;
-  real log_lik[T];
+  array[T] real log_lik;
   corr_matrix[nt] corC;
-  corr_matrix[nt] corH[T];
+  array[T] corr_matrix[nt] corH;
   row_vector[nt] C_var;
 
   for(q in 1:Q) {

--- a/inst/stan/CCCMGARCH.stan
+++ b/inst/stan/CCCMGARCH.stan
@@ -35,9 +35,9 @@ parameters {
   // GARCH h parameters on variance metric
   vector[nt] c_h; 
   // vector<lower=0, upper = 1 >[nt] a_h[Q];
-  simplex[Q] a_h_simplex[nt];
+  array[nt] simplex[Q] a_h_simplex;
   vector<lower=0, upper = 1>[nt] a_h_sum;
-  simplex[P] b_h_simplex[nt];
+  array[nt] simplex[P] b_h_simplex;
   vector[nt] b_h_sum_s;
   // vector<lower=0, upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
 
@@ -52,17 +52,17 @@ parameters {
 
 }
 transformed parameters {
-  cov_matrix[nt] H[T];
-  vector[nt] rr[T-1];
-  vector[nt] mu[T];
-  vector[nt] D[T];
-  real<lower = 0> vd[nt];
-  real<lower = 0> ma_d[nt];
-  real<lower = 0> ar_d[nt];
-  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_sum);
+  array[T] cov_matrix[nt] H;
+  array[T-1] vector[nt] rr;
+  array[T] vector[nt] mu;
+  array[T] vector[nt] D;
+  array[nt] real<lower = 0> vd;
+  array[nt] real<lower = 0> ma_d;
+  array[nt] real<lower = 0> ar_d;
+  array[Q] vector<lower=0, upper = 1>[nt] a_h = simplex_to_bh(a_h_simplex, a_h_sum);
   vector[nt] UPs = upper_limits(a_h);
   vector[nt] ULs = raw_sum_to_b_h_sum(b_h_sum_s, UPs);
-  vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);
+  array[P] vector<lower = 0, upper = 1>[nt] b_h = simplex_to_bh(b_h_simplex, ULs);
   // Initialize t=1
   // Check "Order Sensitivity and Repeated Variables" in stan reference manual
   mu[1,] = phi0;
@@ -129,8 +129,8 @@ model {
 }
 generated quantities {
   matrix[nt,T] rts_out;
-  real log_lik[T];
-  corr_matrix[nt] corH[T];
+  array[T] real log_lik;
+  array[T] corr_matrix[nt] corH;
   vector<lower=0>[nt] c_h_var = exp(c_h);
 
   // retrodict

--- a/inst/stan/DCCMGARCH.stan
+++ b/inst/stan/DCCMGARCH.stan
@@ -38,9 +38,9 @@ parameters {
   // GARCH h parameters on variance metric
   vector[nt] c_h; // variance on log metric 
   // vector<lower = 0,  upper = 1 >[nt] a_h[Q];
-  simplex[Q] a_h_simplex[nt];
+  array[nt] simplex[Q] a_h_simplex;
   vector<lower=0, upper = 1>[nt] a_h_sum;
-  simplex[P] b_h_simplex[nt]; // Simplex for b_h within each timeseries
+  array[nt] simplex[P] b_h_simplex; // Simplex for b_h within each timeseries
   vector[nt] b_h_sum_s; // Unconstrained b_h_sum values. b_h[i] = U[i] b_h_simplex[i]; U[i] ~ U(0, 1 - sum(a_h[i]))
   // vector<lower = 0,  upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
   // GARCH q parameters 
@@ -59,21 +59,21 @@ parameters {
 }
 
 transformed parameters {
-  cov_matrix[nt] H[T];
-  corr_matrix[nt] R[T];
-  vector[nt] rr[T-1];
-  vector[nt] mu[T];
-  vector[nt] D[T];
-  cov_matrix[nt] Qr[T];
-  vector[nt] Qr_sdi[T];
-  vector[nt] u[T];
-  real<lower = 0> vd[nt];
-  real<lower = 0> ma_d[nt];
-  real<lower = 0> ar_d[nt];  
-  vector<lower=0, upper = 1>[nt] a_h[Q] = simplex_to_bh(a_h_simplex, a_h_sum);
+  array[T] cov_matrix[nt] H;
+  array[T] corr_matrix[nt] R;
+  array[T-1] vector[nt] rr;
+  array[T] vector[nt] mu;
+  array[T] vector[nt] D;
+  array[T] cov_matrix[nt] Qr;
+  array[T] vector[nt] Qr_sdi;
+  array[T] vector[nt] u;
+  array[nt] real<lower = 0> vd;
+  array[nt] real<lower = 0> ma_d;
+  array[nt] real<lower = 0> ar_d;  
+  array[Q] vector<lower=0, upper = 1>[nt] a_h = simplex_to_bh(a_h_simplex, a_h_sum);
   vector[nt] UPs = upper_limits(a_h);
   vector[nt] ULs = raw_sum_to_b_h_sum(b_h_sum_s, UPs);
-  vector<lower = 0, upper = 1>[nt] b_h[P] = simplex_to_bh(b_h_simplex, ULs);
+  array[P] vector<lower = 0, upper = 1>[nt] b_h = simplex_to_bh(b_h_simplex, ULs);
   
   // Initialize t=1
   mu[1,] = phi0;
@@ -162,8 +162,8 @@ model {
 }
 generated quantities {
   matrix[nt,T] rts_out;
-  real log_lik[T];
-  corr_matrix[nt] corH[T];
+  array[T] real log_lik;
+  array[T] corr_matrix[nt] corH;
   // for the no-predictor case
   vector<lower=0>[nt] c_h_var = exp(c_h);
   // retrodict

--- a/inst/stan/data/data.stan
+++ b/inst/stan/data/data.stan
@@ -2,7 +2,7 @@ int<lower=2> T; // lengh of time series
 int<lower=2> nt;    // number of time series
 int<lower=1> Q; // MA component in MGARCH(P,Q), matrix A
 int<lower=1> P; // AR component in MGARCH(P,Q), matrix B
-vector[nt] rts[T];  // multivariate time-series
-vector[nt] xC[T];  // time-varying predictor for constant variance
+array[T] vector[nt] rts;  // multivariate time-series
+array[T] vector[nt] xC;  // time-varying predictor for constant variance
 int<lower=0, upper=1> distribution; // 0 = Normal; 1 = student_t
 int<lower=0, upper=2> meanstructure; // Select model for location

--- a/inst/stan/data/gq_data.stan
+++ b/inst/stan/data/gq_data.stan
@@ -2,11 +2,11 @@ int<lower=2> T;
 int<lower=2> nt;    // number of time series
 int<lower=1> Q; // MA component in MGARCH(P,Q), matrix A
 int<lower=1> P; // AR component in MGARCH(P,Q), matrix B  
-vector[nt] rts[T];  // multivariate time-series
-vector[nt] xC[T];  // time-varying predictor for conditional H
+array[T] vector[nt] rts;  // multivariate time-series
+array[T] vector[nt] xC;  // time-varying predictor for conditional H
 int<lower=0, upper=1> distribution; // 0 = Normal; 1 = student_t
 int<lower=0, upper=2> meanstructure; // Select model for location
 int<lower=1> ahead; // forecasted periods
-vector[nt] xC_p[ahead];  // time-varying predictor for conditional H
-vector[nt] future_rts[ahead]; // future observations to obtain log_lik
+array[ahead] vector[nt] xC_p;  // time-varying predictor for conditional H
+array[ahead] vector[nt] future_rts; // future observations to obtain log_lik
 int<lower = 0, upper = 1> compute_log_lik;

--- a/inst/stan/forecastBEKK.stan
+++ b/inst/stan/forecastBEKK.stan
@@ -38,33 +38,33 @@ parameters {
   //  cholesky_factor_cov[nt] Cnst; // Const is symmetric, A, B, are not
   cov_matrix[nt] Cnst; // Const is symmetric, A, B, are not  
 
-  cov_matrix[nt] H[T];
-  matrix[nt,nt] rr[T-1];
-  vector[nt] mu[T];
-  matrix[nt, nt] A[Q];
-  matrix[nt, nt] B[P];
-  corr_matrix[nt] corH[T];
+  array[T] cov_matrix[nt] H;
+  array[T-1] matrix[nt,nt] rr;
+  array[T] vector[nt] mu;
+  array[Q] matrix[nt, nt] A;
+  array[P] matrix[nt, nt] B;
+  array[T] corr_matrix[nt] corH;
 }
 
 generated quantities {
   // Define matrix for rts prediction
-  vector[nt] rts_p[ahead + max(Q,P)];
-  vector[nt] rts_forecasted[ahead];
+  array[ahead + max(Q,P)] vector[nt] rts_p;
+  array[ahead] vector[nt] rts_forecasted;
   
-  cov_matrix[nt] H_p[ahead + max(Q,P)];
-  corr_matrix[nt] R_p[ahead + max(Q,P)];
-  cov_matrix[nt] H_forecasted[ahead];
-  corr_matrix[nt] R_forecasted[ahead];
+  array[ahead + max(Q,P)] cov_matrix[nt] H_p;
+  array[ahead + max(Q,P)] corr_matrix[nt] R_p;
+  array[ahead] cov_matrix[nt] H_forecasted;
+  array[ahead] corr_matrix[nt] R_forecasted;
 
-  matrix[nt,nt] rr_p[ahead + max(Q,P)];
-  vector[nt] mu_p[ahead + max(Q,P)];
-  vector[nt] mu_forecasted[ahead];
+  array[ahead + max(Q,P)] matrix[nt,nt] rr_p;
+  array[ahead + max(Q,P)] vector[nt] mu_p;
+  array[ahead] vector[nt] mu_forecasted;
 
   matrix[nt+1, nt] beta = append_row( beta0, diag_matrix(beta1) );
 
   // log lik for LFO-CV
   // only compute log_lik if it is actually requested
-  real log_lik[compute_log_lik ==1 ? ahead:0];
+  array[compute_log_lik ==1 ? ahead:0] real log_lik;
   
   // Placeholders
   matrix[nt, nt] A_part_p;

--- a/inst/stan/forecastCCC.stan
+++ b/inst/stan/forecastCCC.stan
@@ -25,8 +25,8 @@ parameters {
   //  CCC specifics
   //  GARCH h parameters on variance metric
   vector[nt] c_h;
-  vector<lower=0, upper = 1 >[nt] a_h[Q];
-  vector<lower=0, upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
+  array[Q] vector<lower=0, upper = 1 >[nt] a_h;
+  array[P] vector<lower=0, upper = 1 >[nt] b_h; // TODO actually: 1 - a_h, across all Q and P...
 
   // GARCH constant correlation
   corr_matrix[nt] R;
@@ -34,36 +34,36 @@ parameters {
   // D1 init
   vector<lower = 0>[nt] D1_init;
 
-  cov_matrix[nt] H[T];
-  vector[nt] rr[T-1];
-  vector[nt] mu[T]; 
-  vector[nt] D[T];
+  array[T] cov_matrix[nt] H;
+  array[T-1] vector[nt] rr;
+  array[T] vector[nt] mu; 
+  array[T] vector[nt] D;
 }
 
 generated quantities {
   // Params for prediction
-  vector[nt] D_p[ahead + max(Q,P)];
-  corr_matrix[nt] R_p[ahead + max(Q, P)] = rep_array(R, ahead + max(Q, P)); // R_p = R for all t.
-  corr_matrix[nt] R_forecasted[ahead] = rep_array(R, ahead);
+  array[ahead + max(Q,P)] vector[nt] D_p;
+  array[ahead + max(Q, P)] corr_matrix[nt] R_p = rep_array(R, ahead + max(Q, P)); // R_p = R for all t.
+  array[ahead] corr_matrix[nt] R_forecasted = rep_array(R, ahead);
 
-  cov_matrix[nt] H_p[ahead + max(Q,P)];
-  cov_matrix[nt] H_forecasted[ahead];
+  array[ahead + max(Q,P)] cov_matrix[nt] H_p;
+  array[ahead] cov_matrix[nt] H_forecasted;
   
   // Define Vector that contains max of Q or P lag plus the forecasted ahead
-  vector[nt] mu_p[ahead + max(Q,P)];
-  vector[nt] mu_forecasted[ahead];
+  array[ahead + max(Q,P)] vector[nt] mu_p;
+  array[ahead] vector[nt] mu_forecasted;
   // Define matrix for rts prediction
-  vector[nt] rts_p[ahead + max(Q,P)];
-  vector[nt] rts_forecasted[ahead];
-  vector[nt] rr_p[ahead + max(Q,P)];
+  array[ahead + max(Q,P)] vector[nt] rts_p;
+  array[ahead] vector[nt] rts_forecasted;
+  array[ahead + max(Q,P)] vector[nt] rr_p;
 
   // log lik for LFO-CV
   // only compute log_lik if it is actually requested
-  real log_lik[ compute_log_lik ==1 ? ahead:0];
+  array[ compute_log_lik ==1 ? ahead:0] real log_lik;
   
-  real<lower = 0> vd[nt];
-  real<lower = 0> ma_d[nt];
-  real<lower = 0> ar_d[nt];
+  array[nt] real<lower = 0> vd;
+  array[nt] real<lower = 0> ma_d;
+  array[nt] real<lower = 0> ar_d;
   
   // Populate with non-NA values to avoid Error in stan
   mu_p[ 1:(ahead + max(Q,P)), ] = mu[  1:(ahead + max(Q,P)), ];

--- a/inst/stan/forecastDCC.stan
+++ b/inst/stan/forecastDCC.stan
@@ -24,8 +24,8 @@ parameters {
   
    // GARCH h parameters on variance metric
   vector[nt] c_h;
-  vector<lower=0 >[nt] a_h[Q];
-  vector<lower=0, upper = 1 >[nt] b_h[P]; // TODO actually: 1 - a_h, across all Q and P...
+  array[Q] vector<lower=0 >[nt] a_h;
+  array[P] vector<lower=0, upper = 1 >[nt] b_h; // TODO actually: 1 - a_h, across all Q and P...
 
   // GARCH q parameters
   real<lower=0, upper = 1 > a_q; //
@@ -33,39 +33,39 @@ parameters {
   corr_matrix[nt] S;  // DCC keeps this constant
 
   // inits
-  cov_matrix[nt] H[T];
-  corr_matrix[nt] R[T];
-  vector[nt] rr[T-1];
-  vector[nt] mu[T];
-  vector[nt] D[T];
-  cov_matrix[nt] Qr[T];
-  vector[nt] Qr_sdi[T];
-  vector[nt] u[T];
+  array[T] cov_matrix[nt] H;
+  array[T] corr_matrix[nt] R;
+  array[T-1] vector[nt] rr;
+  array[T] vector[nt] mu;
+  array[T] vector[nt] D;
+  array[T] cov_matrix[nt] Qr;
+  array[T] vector[nt] Qr_sdi;
+  array[T] vector[nt] u;
 }
 
 generated quantities {
   // Define matrix for rts prediction
-  vector[nt] rts_p[ahead + max(Q,P)];
-  vector[nt] rts_forecasted[ahead];
-  cov_matrix[nt] H_p[ahead + max(Q,P)];
-  cov_matrix[nt] H_forecasted[ahead];
-  corr_matrix[nt] R_p[ahead + max(Q,P)]; // 
-  corr_matrix[nt] R_forecasted[ahead]; // 
-  vector[nt] rr_p[ahead + max(Q,P)];
-  vector[nt] mu_p[ahead + max(Q,P)];
-  vector[nt] mu_forecasted[ahead];
-  vector[nt] D_p[ahead + max(Q,P)];
-  cov_matrix[nt] Qr_p[ahead + max(Q,P)];
-  vector[nt] u_p[ahead + max(Q,P)];
-  vector[nt] Qr_sdi_p[ahead + max(Q,P)];
+  array[ahead + max(Q,P)] vector[nt] rts_p;
+  array[ahead] vector[nt] rts_forecasted;
+  array[ahead + max(Q,P)] cov_matrix[nt] H_p;
+  array[ahead] cov_matrix[nt] H_forecasted;
+  array[ahead + max(Q,P)] corr_matrix[nt] R_p; // 
+  array[ahead] corr_matrix[nt] R_forecasted; // 
+  array[ahead + max(Q,P)] vector[nt] rr_p;
+  array[ahead + max(Q,P)] vector[nt] mu_p;
+  array[ahead] vector[nt] mu_forecasted;
+  array[ahead + max(Q,P)] vector[nt] D_p;
+  array[ahead + max(Q,P)] cov_matrix[nt] Qr_p;
+  array[ahead + max(Q,P)] vector[nt] u_p;
+  array[ahead + max(Q,P)] vector[nt] Qr_sdi_p;
   // log lik for LFO-CV
 // only compute log_lik if it is actually requested 
-  real log_lik[compute_log_lik ==1 ? ahead:0];
+  array[compute_log_lik ==1 ? ahead:0] real log_lik;
   
   // Placeholders
-  real<lower = 0> vd_p[nt];
-  real<lower = 0> ma_d_p[nt];
-  real<lower = 0> ar_d_p[nt];
+  array[nt] real<lower = 0> vd_p;
+  array[nt] real<lower = 0> ma_d_p;
+  array[nt] real<lower = 0> ar_d_p;
   
 
   // Populate with non-NA values to avoid Error in stan

--- a/inst/stan/functions/jacobian.stan
+++ b/inst/stan/functions/jacobian.stan
@@ -28,7 +28,7 @@ real a_b_scale(real a, real b, real value) {
   @param a_h Array of vectors [nt, Q].
   @return vector[nt] Upper limits such that sum(b_h{k}) < UpperLimit{k} = 1 - sum(a_h{k})
  */
-vector upper_limits(vector[] a_h) {
+vector upper_limits(array[] vector a_h) {
   int nt = num_elements(a_h[1]);
   int Q = size(a_h);
   vector[nt] a_h_sums;
@@ -68,10 +68,10 @@ vector raw_sum_to_b_h_sum(vector b_h_sum_s, vector upperLimits) {
   @param b_h_sum vector [nt] of the value to which the b_h's should be summed.
   @return An array [P] of vectors [nt].
  */
-vector[] simplex_to_bh(vector[] b_h_simplex, vector b_h_sum) {
+array[] vector simplex_to_bh(array[] vector b_h_simplex, vector b_h_sum) {
   int nt = size(b_h_simplex);
   int P = num_elements(b_h_simplex[1]);
-  vector[nt] b_h[P];
+  array[P] vector[nt] b_h;
   for(k in 1:nt) {
     b_h[1:P, k] = to_array_1d(b_h_simplex[k] * b_h_sum[k]);
   }

--- a/inst/stan/pdBEKKMGARCH.stan
+++ b/inst/stan/pdBEKKMGARCH.stan
@@ -12,7 +12,7 @@ transformed data {
   vector[nt] rts_m;
   vector[nt] rts_sd;
   // off diagonal elements
-  int<lower = 1> od = ( nt*nt - nt ) / 2;
+  int<lower = 1> od = ( nt*nt - nt ) %/% 2;
 #include /transformed_data/xh_marker.stan
 
   if( meanstructure == 0 ){
@@ -42,13 +42,13 @@ parameters {
   // C_sd is defined in tp, as function of betas
   corr_matrix[nt] C_R;
 
-  vector<lower = 0, upper = 1>[nt] A_diag[Q];
-  vector<lower = 0, upper = 1>[nt] B_diag[P];
+  array[Q] vector<lower = 0, upper = 1>[nt] A_diag;
+  array[P] vector<lower = 0, upper = 1>[nt] B_diag;
 
-  vector[ od ] A_lower[Q];
-  vector[ od ] B_lower[P];
-  vector[ od ] A_upper[Q];
-  vector[ od ] B_upper[P];
+  array[Q] vector[ od ] A_lower;
+  array[P] vector[ od ] B_lower;
+  array[Q] vector[ od ] A_upper;
+  array[P] vector[ od ] B_upper;
 
     // H1 init
   cov_matrix[nt] H1_init; 
@@ -56,9 +56,9 @@ parameters {
 
 }
 transformed parameters {
-  cov_matrix[nt] H[T];
-  matrix[nt,nt] rr[T-1];
-  vector[nt] mu[T];
+  array[T] cov_matrix[nt] H;
+  array[T-1] matrix[nt,nt] rr;
+  array[T] vector[nt] mu;
 
   matrix[nt, nt] A_part = diag_matrix( rep_vector(0.0, nt));
   matrix[nt, nt] B_part = diag_matrix( rep_vector(0.0, nt));
@@ -68,8 +68,8 @@ transformed parameters {
   cov_matrix[nt] Cnst; // Const is symmetric, A, B, are not  
 
   // Construct square matrices with positive diagonals
-  matrix[nt, nt] A_raw[Q]; 
-  matrix[nt, nt] B_raw[P];
+  array[Q] matrix[nt, nt] A_raw; 
+  array[P] matrix[nt, nt] B_raw;
 
    for(q in 1:Q) {
     int L = 0;
@@ -181,12 +181,12 @@ model {
 }
 //
 generated quantities {
-  matrix[nt, nt] A[Q] = A_raw;
-  matrix[nt, nt] B[P] = B_raw;
+  array[Q] matrix[nt, nt] A = A_raw;
+  array[P] matrix[nt, nt] B = B_raw;
   matrix[nt,T] rts_out;
-  real log_lik[T];
+  array[T] real log_lik;
   corr_matrix[nt] corC;
-  corr_matrix[nt] corH[T];
+  array[T] corr_matrix[nt] corH;
   row_vector[nt] C_var;
 
   

--- a/inst/stan/transformed_data/xh_marker.stan
+++ b/inst/stan/transformed_data/xh_marker.stan
@@ -1,5 +1,5 @@
 // Check whether xC contains a predictor or not.
-matrix[nt, nt] xC_m[T];
+array[T] matrix[nt, nt] xC_m;
 int<lower = 0> xC_marker = 0;
 real<lower = 0> cp;
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
